### PR TITLE
3 commits for XStreamity

### DIFF
--- a/XStreamity/usr/lib/enigma2/python/Plugins/Extensions/XStreamity/hidden.py
+++ b/XStreamity/usr/lib/enigma2/python/Plugins/Extensions/XStreamity/hidden.py
@@ -108,6 +108,7 @@ class XStreamity_HiddenCategories(Screen):
     def refresh(self):
         self.drawList = []
         self.drawList = [self.buildListEntry(x[0], x[1], x[2]) for x in self.startList]
+        self['hidden_list'].setList(self.drawList)
         self['hidden_list'].updateList(self.drawList)
 
     def toggleSelection(self):

--- a/XStreamity/usr/lib/enigma2/python/Plugins/Extensions/XStreamity/streamplayer.py
+++ b/XStreamity/usr/lib/enigma2/python/Plugins/Extensions/XStreamity/streamplayer.py
@@ -534,9 +534,16 @@ class XStreamity_StreamPlayer(
             self.hasStreamData = True
 
     def __evEOF(self):
+        print("[XStreamity_StreamPlayer]** evEOF **")
         if self.servicetype == "1":
-            self.session.nav.stopService()
-            self.session.nav.playService(self.reference, forceRestart=True)
+                self.retries += 1
+                if self.retries > 3:
+                        self.retries = 0
+                        print("[XStreamity_StreamPlayer]** evEOF retries over 3 and self-servicetype =1 suggests multiple url redirect. so retry with servicetype = 4092 **")                      
+                        self.session.open(MessageBox, _("multiple url redirects - unable to run streamtype '1', trying streamtype '4097'."), MessageBox.TYPE_INFO, timeout=3)
+                        self.session.nav.stopService()
+                        self.servicetype = "4097"                        
+                        self.playStream(self.servicetype, self.streamurl)
 
     def checkStream(self):
         if self.hasStreamData is False:

--- a/XStreamity/usr/lib/enigma2/python/Plugins/Extensions/XStreamity/streamplayer.py
+++ b/XStreamity/usr/lib/enigma2/python/Plugins/Extensions/XStreamity/streamplayer.py
@@ -388,16 +388,15 @@ class XStreamity_StreamPlayer(
             return
 
     def playStream(self, servicetype, streamurl):
-        self["epg_description"].setText(glob.currentepglist[glob.currentchannelistindex][4])
-        self["nowchannel"].setText(glob.currentchannelist[glob.currentchannelistindex][0])
-        self["nowtitle"].setText(glob.currentepglist[glob.currentchannelistindex][3])
-        self["nexttitle"].setText(glob.currentepglist[glob.currentchannelistindex][6])
-        self["nowtime"].setText(glob.currentepglist[glob.currentchannelistindex][2])
-        self["nexttime"].setText(glob.currentepglist[glob.currentchannelistindex][5])
-        self["streamcat"].setText("Live")
-        self["streamtype"].setText(str(servicetype))
-
-        try:
+        try:    
+            self["epg_description"].setText(glob.currentepglist[glob.currentchannelistindex][4])
+            self["nowchannel"].setText(glob.currentchannelist[glob.currentchannelistindex][0])
+            self["nowtitle"].setText(glob.currentepglist[glob.currentchannelistindex][3])
+            self["nexttitle"].setText(glob.currentepglist[glob.currentchannelistindex][6])
+            self["nowtime"].setText(glob.currentepglist[glob.currentchannelistindex][2])
+            self["nexttime"].setText(glob.currentepglist[glob.currentchannelistindex][5])
+            self["streamcat"].setText("Live")
+            self["streamtype"].setText(str(servicetype))
             self["extension"].setText(str(os.path.splitext(streamurl)[-1]))
         except:
             pass


### PR DESCRIPTION
1. hidden.py - "setList" before "updateList" - stops crash in list.py (same as Jedi_make Pull by Huevos)
2. streamplayer - maybe fixed, but I have had several instances where fields are  not set - hence extended try/except
3. streamplayer - this is a repeated EOF loop between httpstream.cpp & filepush.cpp when the stream url -> redirects and then -> redirects again (happens on a provider I use)
I have tried fixing the cpp code, but so far failed, hence this is a catch all that retries automatically using streamtype 4097